### PR TITLE
feat: scaffold SwipeFlow Expo app

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['react', '@typescript-eslint'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 90
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# swype
+# SwipeFlow
+
+SwipeFlow is a swipe-first triage tool prototype built with Expo Router, Reanimated, and Zustand. The app connects to mocked data sources and lets you map swipe directions to mocked actions, swipe through paginated decks, undo actions, and monitor activity with retry + backoff.
+
+## Getting Started
+
+```bash
+npm install -g expo-cli # if you don't already have the Expo CLI
+pnpm install           # or use `npm install` / `yarn install`
+pnpm exec expo start   # or `npx expo start`
+```
+
+Expo will provide a QR code and platform options to launch the app in development.
+
+## Features
+
+- Mock connector selection (Trello, Gmail, Notion)
+- Customizable swipe mappings persisted locally
+- Tinder-style deck with gesture-driven left/right swipes and accessibility buttons
+- Optimistic queue with background retry (exponential backoff) and undo history (10 actions)
+- Activity log showing operation status with retry controls
+- Settings with haptics toggle and undo cache clearing
+
+## Known Limitations / Next Steps
+
+- Connectors are mocked; real OAuth + APIs would replace the service stubs
+- Only left/right swipes are implemented (no vertical gestures yet)
+- Undo issues a mock compensating action rather than a real API rollback
+- UI is optimized for phones; tablet/Desktop layout could be improved

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,35 @@
+import { ExpoConfig } from 'expo';
+
+const config: ExpoConfig = {
+  name: 'SwipeFlow',
+  slug: 'swipeflow',
+  version: '1.0.0',
+  orientation: 'portrait',
+  userInterfaceStyle: 'automatic',
+  updates: {
+    fallbackToCacheTimeout: 0
+  },
+  assetBundlePatterns: ['**/*'],
+  ios: {
+    supportsTablet: true
+  },
+  android: {
+    adaptiveIcon: {
+      backgroundColor: '#ffffff'
+    }
+  },
+  web: {
+    bundler: 'metro',
+    output: 'static'
+  },
+  experiments: {
+    typedRoutes: true
+  },
+  extra: {
+    router: {
+      origin: 'src/app'
+    }
+  }
+};
+
+export default config;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin',
+      require.resolve('expo-router/babel')
+    ]
+  };
+};

--- a/expo-env.d.ts
+++ b/expo-env.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      EXPO_ROUTER_APP_ROOT?: string;
+    }
+  }
+}
+
+export {};

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+process.env.EXPO_ROUTER_APP_ROOT = 'src/app';
+import 'expo-router/entry';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "swipeflow",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-native-community/hooks": "^2.9.0",
+    "expo": "~51.0.0",
+    "expo-haptics": "~12.0.0",
+    "expo-router": "^3.5.8",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.74.3",
+    "react-native-gesture-handler": "^2.16.1",
+    "react-native-reanimated": "^3.12.1",
+    "react-native-safe-area-context": "^4.10.1",
+    "react-native-screens": "^3.31.1",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "immer": "^10.0.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.5",
+    "@types/react": "18.2.79",
+    "@types/react-native": "0.73.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.1",
+    "@typescript-eslint/parser": "^7.8.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.3",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { Stack, SplashScreen } from 'expo-router';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import Toast from '@/components/Toast';
+import { useAppStore } from '@/store/useAppStore';
+
+SplashScreen.preventAutoHideAsync().catch(() => {});
+
+const RootLayout = () => {
+  const init = useAppStore((state) => state.init);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      await init();
+      SplashScreen.hideAsync();
+    };
+    bootstrap().catch(() => SplashScreen.hideAsync());
+  }, [init]);
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <StatusBar style="dark" />
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            animation: 'fade'
+          }}
+        />
+        <Toast />
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
+};
+
+export default RootLayout;

--- a/src/app/activity.tsx
+++ b/src/app/activity.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { View, Text, FlatList, StyleSheet, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useAppStore } from '@/store/useAppStore';
+import { colors, spacing, radii } from '@/theme';
+
+const statusColors: Record<'pending' | 'success' | 'failed', string> = {
+  pending: colors.primary,
+  success: colors.success,
+  failed: colors.danger
+};
+
+const ActivityScreen = () => {
+  const router = useRouter();
+  const operations = useAppStore((state) => state.queue);
+  const retry = useAppStore((state) => state.retry);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>Back</Text>
+        </Pressable>
+        <Text style={styles.title}>Activity</Text>
+      </View>
+      <FlatList
+        data={operations}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <View style={styles.itemHeader}>
+              <Text style={styles.itemTitle}>{item.item.title}</Text>
+              <View
+                style={[styles.statusBadge, { backgroundColor: statusColors[item.status] }]}
+              >
+                <Text style={styles.statusText}>{item.status.toUpperCase()}</Text>
+              </View>
+            </View>
+            <Text style={styles.meta}>Direction: {item.direction.toUpperCase()}</Text>
+            <Text style={styles.meta}>Action: {item.action.type}</Text>
+            {item.error ? <Text style={styles.error}>{item.error}</Text> : null}
+            {item.status === 'failed' ? (
+              <Pressable style={styles.retryButton} onPress={() => retry(item.id)}>
+                <Text style={styles.retryText}>Retry</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        )}
+        ListEmptyComponent={() => (
+          <View style={styles.empty}>
+            <Text style={styles.emptyText}>No operations yet.</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: spacing.xl,
+    gap: spacing.lg
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md
+  },
+  backButton: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  backText: {
+    color: colors.text
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text
+  },
+  list: {
+    gap: spacing.md,
+    paddingTop: spacing.md
+  },
+  item: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    padding: spacing.lg,
+    gap: spacing.sm
+  },
+  itemHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  itemTitle: {
+    fontWeight: '600',
+    color: colors.text
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.sm
+  },
+  statusText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600'
+  },
+  meta: {
+    color: colors.muted,
+    fontSize: 12
+  },
+  error: {
+    color: colors.danger,
+    fontSize: 12
+  },
+  retryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.md,
+    backgroundColor: colors.primary
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600'
+  },
+  empty: {
+    padding: spacing.xl,
+    alignItems: 'center'
+  },
+  emptyText: {
+    color: colors.muted
+  }
+});
+
+export default ActivityScreen;

--- a/src/app/connect.tsx
+++ b/src/app/connect.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { ConnectorId } from '@/types';
+import { useAppStore } from '@/store/useAppStore';
+import { connectorNames } from '@/services/connectors';
+import { colors, spacing, radii } from '@/theme';
+
+const connectors: ConnectorId[] = ['trello', 'gmail', 'notion'];
+
+const ConnectScreen = () => {
+  const router = useRouter();
+  const setAccount = useAppStore((state) => state.setAccount);
+
+  const handleSelect = async (connector: ConnectorId) => {
+    await setAccount(connector);
+    router.replace('/map');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Connect a workspace</Text>
+      <Text style={styles.subtitle}>Pick a mock connector to start swiping.</Text>
+      <FlatList
+        data={connectors}
+        keyExtractor={(item) => item}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <Pressable style={styles.card} onPress={() => handleSelect(item)}>
+            <Text style={styles.cardTitle}>{connectorNames[item]}</Text>
+            <Text style={styles.cardSubtitle}>Mock integration</Text>
+          </Pressable>
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: spacing.xl,
+    gap: spacing.lg,
+    backgroundColor: colors.background
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.text
+  },
+  subtitle: {
+    fontSize: 16,
+    color: colors.muted
+  },
+  list: {
+    gap: spacing.md
+  },
+  card: {
+    padding: spacing.lg,
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.text
+  },
+  cardSubtitle: {
+    marginTop: spacing.xs,
+    color: colors.muted
+  }
+});
+
+export default ConnectScreen;

--- a/src/app/deck.tsx
+++ b/src/app/deck.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+import SwipeDeck from '@/components/SwipeDeck';
+import { useAppStore } from '@/store/useAppStore';
+import { colors, spacing, radii } from '@/theme';
+import { describeConnectorAction } from '@/services/connectors';
+
+const DeckScreen = () => {
+  const router = useRouter();
+  const account = useAppStore((state) => state.account);
+  const deck = useAppStore((state) => state.deck);
+  const loadPage = useAppStore((state) => state.loadPage);
+  const swipe = useAppStore((state) => state.swipe);
+  const undo = useAppStore((state) => state.undo);
+  const swipeMap = useAppStore((state) => state.swipeMap);
+  const hasMore = useAppStore((state) => state.hasMore);
+  const loading = useAppStore((state) => state.loading);
+  const hapticsEnabled = useAppStore((state) => state.hapticsEnabled);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!account) {
+        router.replace('/connect');
+        return () => {};
+      }
+      if (!deck.length) {
+        loadPage().catch(() => undefined);
+      }
+      return () => {};
+    }, [account, deck.length, loadPage, router])
+  );
+
+  const handleSwipe = async (direction: 'left' | 'right') => {
+    if (hapticsEnabled) {
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    await swipe(direction);
+  };
+
+  const leftLabel = useMemo(() => {
+    if (!account) return 'Left';
+    return describeConnectorAction(account.connector, swipeMap.left);
+  }, [account, swipeMap.left]);
+
+  const rightLabel = useMemo(() => {
+    if (!account) return 'Right';
+    return describeConnectorAction(account.connector, swipeMap.right);
+  }, [account, swipeMap.right]);
+
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.title}>SwipeFlow</Text>
+          <Text style={styles.subtitle}>Connected to {account.connector.toUpperCase()}</Text>
+        </View>
+        <View style={styles.headerActions}>
+          <Pressable style={styles.headerButton} onPress={() => router.push('/activity')}>
+            <Text style={styles.headerButtonText}>Activity</Text>
+          </Pressable>
+          <Pressable style={styles.headerButton} onPress={() => router.push('/settings')}>
+            <Text style={styles.headerButtonText}>Settings</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <SwipeDeck
+        items={deck}
+        onSwipe={handleSwipe}
+        leftLabel={leftLabel}
+        rightLabel={rightLabel}
+        onLeftPress={() => handleSwipe('left')}
+        onRightPress={() => handleSwipe('right')}
+      />
+
+      <View style={styles.footer}>
+        <Pressable style={styles.undoButton} onPress={() => undo()}>
+          <Text style={styles.undoText}>Undo</Text>
+        </Pressable>
+        {loading ? <ActivityIndicator color={colors.primary} /> : null}
+        {!loading && !deck.length && hasMore ? (
+          <Pressable style={styles.loadMore} onPress={() => loadPage()}>
+            <Text style={styles.loadMoreText}>Load more</Text>
+          </Pressable>
+        ) : null}
+        {!hasMore && !deck.length ? (
+          <Text style={styles.endText}>You reached the end of the queue.</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: spacing.xl,
+    gap: spacing.lg
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: colors.text
+  },
+  subtitle: {
+    color: colors.muted,
+    marginTop: spacing.xs
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: spacing.sm
+  },
+  headerButton: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  headerButtonText: {
+    color: colors.text,
+    fontWeight: '600'
+  },
+  footer: {
+    gap: spacing.sm
+  },
+  undoButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.primary
+  },
+  undoText: {
+    color: colors.primary,
+    fontWeight: '600'
+  },
+  loadMore: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  loadMoreText: {
+    color: colors.text
+  },
+  endText: {
+    color: colors.muted
+  }
+});
+
+export default DeckScreen;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,0 +1,15 @@
+import { Redirect } from 'expo-router';
+import React from 'react';
+import { useAppStore } from '@/store/useAppStore';
+
+const Index = () => {
+  const account = useAppStore((state) => state.account);
+
+  if (!account) {
+    return <Redirect href="/connect" />;
+  }
+
+  return <Redirect href="/deck" />;
+};
+
+export default Index;

--- a/src/app/map.tsx
+++ b/src/app/map.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, Pressable, ScrollView } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useAppStore } from '@/store/useAppStore';
+import { connectorActions, describeConnectorAction } from '@/services/connectors';
+import { ActionConfig } from '@/types';
+import { colors, spacing, radii } from '@/theme';
+
+const MapScreen = () => {
+  const router = useRouter();
+  const account = useAppStore((state) => state.account);
+  const swipeMap = useAppStore((state) => state.swipeMap);
+  const setSwipeMap = useAppStore((state) => state.setSwipeMap);
+
+  const actions = useMemo(() => {
+    if (!account) return [];
+    return connectorActions[account.connector]();
+  }, [account]);
+
+  if (!account) {
+    router.replace('/connect');
+    return null;
+  }
+
+  const handleSelect = (direction: 'left' | 'right', action: ActionConfig) => {
+    void setSwipeMap({ [direction]: action });
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Configure your swipes</Text>
+      <Text style={styles.subtitle}>
+        Map each direction to what should happen inside {account.connector.toUpperCase()}.
+      </Text>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Left swipe</Text>
+        <View style={styles.grid}>
+          {actions.map((action) => {
+            const isActive = JSON.stringify(action) === JSON.stringify(swipeMap.left);
+            return (
+              <Pressable
+                key={`${action.type}-${action.label ?? ''}-${Object.values(action.params ?? {}).join('-')}`}
+                style={[styles.actionCard, isActive && styles.actionCardActive]}
+                onPress={() => handleSelect('left', action)}
+              >
+                <Text style={styles.cardTitle}>{action.label ?? action.type}</Text>
+                <Text style={styles.cardDescription}>
+                  {describeConnectorAction(account.connector, action)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Right swipe</Text>
+        <View style={styles.grid}>
+          {actions.map((action) => {
+            const isActive = JSON.stringify(action) === JSON.stringify(swipeMap.right);
+            return (
+              <Pressable
+                key={`right-${action.type}-${action.label ?? ''}-${Object.values(action.params ?? {}).join('-')}`}
+                style={[styles.actionCard, isActive && styles.actionCardActive]}
+                onPress={() => handleSelect('right', action)}
+              >
+                <Text style={styles.cardTitle}>{action.label ?? action.type}</Text>
+                <Text style={styles.cardDescription}>
+                  {describeConnectorAction(account.connector, action)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <Pressable style={styles.primaryButton} onPress={() => router.replace('/deck')}>
+        <Text style={styles.primaryText}>Start swiping</Text>
+      </Pressable>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background
+  },
+  content: {
+    padding: spacing.xl,
+    gap: spacing.xl
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.text
+  },
+  subtitle: {
+    fontSize: 16,
+    color: colors.muted
+  },
+  section: {
+    gap: spacing.md
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text
+  },
+  grid: {
+    gap: spacing.md
+  },
+  actionCard: {
+    padding: spacing.lg,
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  actionCardActive: {
+    borderColor: colors.primary,
+    shadowColor: colors.primary,
+    shadowOpacity: 0.2,
+    shadowRadius: 10,
+    elevation: 3
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text
+  },
+  cardDescription: {
+    marginTop: spacing.xs,
+    color: colors.muted,
+    fontSize: 14
+  },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    borderRadius: radii.md,
+    alignItems: 'center'
+  },
+  primaryText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16
+  }
+});
+
+export default MapScreen;

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable, Switch } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useAppStore } from '@/store/useAppStore';
+import { describeConnectorAction } from '@/services/connectors';
+import { colors, spacing, radii } from '@/theme';
+
+const SettingsScreen = () => {
+  const router = useRouter();
+  const account = useAppStore((state) => state.account);
+  const swipeMap = useAppStore((state) => state.swipeMap);
+  const clearCache = useAppStore((state) => state.clearCache);
+  const hapticsEnabled = useAppStore((state) => state.hapticsEnabled);
+  const setHaptics = useAppStore((state) => state.setHaptics);
+
+  if (!account) {
+    router.replace('/connect');
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>Back</Text>
+        </Pressable>
+        <Text style={styles.title}>Settings</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Swipe mappings</Text>
+        <View style={styles.mappingRow}>
+          <Text style={styles.mappingLabel}>Left</Text>
+          <Text style={styles.mappingValue}>
+            {describeConnectorAction(account.connector, swipeMap.left)}
+          </Text>
+        </View>
+        <View style={styles.mappingRow}>
+          <Text style={styles.mappingLabel}>Right</Text>
+          <Text style={styles.mappingValue}>
+            {describeConnectorAction(account.connector, swipeMap.right)}
+          </Text>
+        </View>
+        <Pressable style={styles.primaryButton} onPress={() => router.push('/map')}>
+          <Text style={styles.primaryText}>Change mappings</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Haptics</Text>
+        <View style={styles.mappingRow}>
+          <Text style={styles.mappingLabel}>Enable haptic feedback</Text>
+          <Switch value={hapticsEnabled} onValueChange={(value) => setHaptics(value)} />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Storage</Text>
+        <Pressable style={styles.secondaryButton} onPress={() => clearCache()}>
+          <Text style={styles.secondaryText}>Clear undo history</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: spacing.xl,
+    gap: spacing.lg
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md
+  },
+  backButton: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  backText: {
+    color: colors.text
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text
+  },
+  section: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    padding: spacing.lg,
+    gap: spacing.md,
+    borderWidth: 1,
+    borderColor: '#e5e7eb'
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text
+  },
+  mappingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  mappingLabel: {
+    color: colors.muted,
+    fontSize: 14
+  },
+  mappingValue: {
+    color: colors.text,
+    fontWeight: '600'
+  },
+  primaryButton: {
+    marginTop: spacing.sm,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    alignItems: 'center'
+  },
+  primaryText: {
+    color: '#fff',
+    fontWeight: '600'
+  },
+  secondaryButton: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.danger,
+    paddingVertical: spacing.sm,
+    alignItems: 'center'
+  },
+  secondaryText: {
+    color: colors.danger,
+    fontWeight: '600'
+  }
+});
+
+export default SettingsScreen;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { Item } from '@/types';
+import { colors, spacing, radii, shadows } from '@/theme';
+
+interface CardProps {
+  item: Item;
+}
+
+export const Card: React.FC<CardProps> = ({ item }) => {
+  return (
+    <View style={styles.container} accessibilityLabel={`Card ${item.title}`}>
+      {item.thumbnailUrl ? (
+        <Image source={{ uri: item.thumbnailUrl }} style={styles.thumbnail} />
+      ) : null}
+      <View style={styles.content}>
+        <Text style={styles.title}>{item.title}</Text>
+        {item.preview ? <Text style={styles.preview}>{item.preview}</Text> : null}
+        {item.meta ? (
+          <Text style={styles.meta}>{Object.values(item.meta).join(' • ')}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    padding: spacing.lg,
+    gap: spacing.md,
+    ...shadows.card
+  },
+  thumbnail: {
+    width: '100%',
+    height: 180,
+    borderRadius: radii.md,
+    backgroundColor: '#d1d5db'
+  },
+  content: {
+    gap: spacing.sm
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.text
+  },
+  preview: {
+    fontSize: 14,
+    color: colors.muted
+  },
+  meta: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    color: colors.muted
+  }
+});
+
+export default Card;

--- a/src/components/SwipeDeck.tsx
+++ b/src/components/SwipeDeck.tsx
@@ -1,0 +1,258 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View, Text, Pressable } from 'react-native';
+import { PanGestureHandler } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  runOnJS
+} from 'react-native-reanimated';
+import { Item } from '@/types';
+import Card from './Card';
+import { colors, radii, spacing } from '@/theme';
+
+const SWIPE_THRESHOLD = 120;
+
+const AnimatedView = Animated.createAnimatedComponent(View);
+
+interface SwipeDeckProps {
+  items: Item[];
+  onSwipe: (direction: 'left' | 'right') => void;
+  renderCard?: (item: Item) => React.ReactNode;
+  leftLabel: string;
+  rightLabel: string;
+  onLeftPress?: () => void;
+  onRightPress?: () => void;
+}
+
+export const SwipeDeck: React.FC<SwipeDeckProps> = ({
+  items,
+  onSwipe,
+  renderCard,
+  leftLabel,
+  rightLabel,
+  onLeftPress,
+  onRightPress
+}) => {
+  const topItem = items[0];
+  const nextItem = items[1];
+
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+
+
+  React.useEffect(() => {
+    translateX.value = 0;
+    translateY.value = 0;
+  }, [topItem, translateX, translateY]);
+  const resetPosition = () => {
+    translateX.value = withSpring(0);
+    translateY.value = withSpring(0);
+  };
+
+  const completeSwipe = (direction: 'left' | 'right') => {
+    runOnJS(onSwipe)(direction);
+    translateX.value = 0;
+    translateY.value = 0;
+  };
+
+  const gestureHandler = useAnimatedGestureHandler({
+    onStart: (_, ctx: { startX: number; startY: number }) => {
+      ctx.startX = translateX.value;
+      ctx.startY = translateY.value;
+    },
+    onActive: (event, ctx) => {
+      translateX.value = ctx.startX + event.translationX;
+      translateY.value = ctx.startY + event.translationY;
+    },
+    onEnd: (event) => {
+      const velocityX = event.velocityX;
+      const shouldSwipeLeft = translateX.value < -SWIPE_THRESHOLD || velocityX < -600;
+      const shouldSwipeRight = translateX.value > SWIPE_THRESHOLD || velocityX > 600;
+
+      if (shouldSwipeLeft) {
+        translateX.value = withTiming(-400, { duration: 200 }, () => {
+          completeSwipe('left');
+        });
+        translateY.value = withTiming(translateY.value, { duration: 200 });
+        return;
+      }
+
+      if (shouldSwipeRight) {
+        translateX.value = withTiming(400, { duration: 200 }, () => {
+          completeSwipe('right');
+        });
+        translateY.value = withTiming(translateY.value, { duration: 200 });
+        return;
+      }
+
+      resetPosition();
+    }
+  });
+
+  const animatedCardStyle = useAnimatedStyle(() => {
+    const rotate = `${translateX.value / 20}deg`;
+    return {
+      transform: [
+        { translateX: translateX.value },
+        { translateY: translateY.value },
+        { rotate }
+      ]
+    };
+  });
+
+  const leftOverlayStyle = useAnimatedStyle(() => {
+    return {
+      opacity: Math.min(1, Math.max(0, -translateX.value / SWIPE_THRESHOLD))
+    };
+  });
+
+  const rightOverlayStyle = useAnimatedStyle(() => {
+    return {
+      opacity: Math.min(1, Math.max(0, translateX.value / SWIPE_THRESHOLD))
+    };
+  });
+
+  const renderTopCard = useMemo(() => {
+    if (!topItem) return null;
+    return renderCard ? renderCard(topItem) : <Card item={topItem} />;
+  }, [topItem, renderCard]);
+
+  const renderNextCard = useMemo(() => {
+    if (!nextItem) return null;
+    return renderCard ? renderCard(nextItem) : <Card item={nextItem} />;
+  }, [nextItem, renderCard]);
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.deckArea}>
+        {nextItem ? (
+          <AnimatedView style={[styles.card, styles.nextCard]}>{renderNextCard}</AnimatedView>
+        ) : null}
+        {topItem ? (
+          <PanGestureHandler onGestureEvent={gestureHandler}>
+            <AnimatedView style={[styles.card, animatedCardStyle]}>
+              {renderTopCard}
+              <Animated.View style={[styles.overlay, styles.leftOverlay, leftOverlayStyle]}>
+                <Text style={styles.overlayText}>{leftLabel}</Text>
+              </Animated.View>
+              <Animated.View style={[styles.overlay, styles.rightOverlay, rightOverlayStyle]}>
+                <Text style={styles.overlayText}>{rightLabel}</Text>
+              </Animated.View>
+            </AnimatedView>
+          </PanGestureHandler>
+        ) : (
+          <View style={[styles.card, styles.emptyCard]}>
+            <Text style={styles.emptyText}>No more items</Text>
+          </View>
+        )}
+      </View>
+      <View style={styles.actions}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Swipe left (${leftLabel})`}
+          onPress={onLeftPress}
+          style={[styles.actionButton, styles.leftButton]}
+        >
+          <Text style={styles.buttonText}>Left</Text>
+          <Text style={styles.buttonHint}>{leftLabel}</Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Swipe right (${rightLabel})`}
+          onPress={onRightPress}
+          style={[styles.actionButton, styles.rightButton]}
+        >
+          <Text style={styles.buttonText}>Right</Text>
+          <Text style={styles.buttonHint}>{rightLabel}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    width: '100%',
+    gap: spacing.lg
+  },
+  deckArea: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  card: {
+    width: '100%',
+    maxWidth: 360,
+    position: 'absolute'
+  },
+  nextCard: {
+    transform: [{ scale: 0.95 }, { translateY: 16 }],
+    opacity: 0.6
+  },
+  emptyCard: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    padding: spacing.xl,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  emptyText: {
+    color: colors.muted,
+    fontSize: 16
+  },
+  overlay: {
+    position: 'absolute',
+    top: spacing.lg,
+    padding: spacing.sm,
+    borderRadius: radii.md,
+    borderWidth: 2
+  },
+  leftOverlay: {
+    left: spacing.lg,
+    borderColor: colors.danger
+  },
+  rightOverlay: {
+    right: spacing.lg,
+    borderColor: colors.success
+  },
+  overlayText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: spacing.md
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.muted
+  },
+  leftButton: {
+    backgroundColor: '#fee2e2'
+  },
+  rightButton: {
+    backgroundColor: '#dcfce7'
+  },
+  buttonText: {
+    fontWeight: '600',
+    fontSize: 16,
+    color: colors.text
+  },
+  buttonHint: {
+    fontSize: 12,
+    color: colors.muted,
+    marginTop: 4
+  }
+});
+
+export default SwipeDeck;

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StyleSheet, Text, View, Pressable, Platform } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { useToastStore } from '@/store/useToastStore';
+import { colors, radii, spacing } from '@/theme';
+
+const AnimatedView = Animated.createAnimatedComponent(View);
+
+export const Toast: React.FC = () => {
+  const { visible, message, actionLabel, onAction } = useToastStore();
+  const opacity = useSharedValue(0);
+
+  React.useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, { duration: 200 });
+  }, [visible, opacity]);
+
+  const containerStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: withTiming(visible ? 0 : 10, { duration: 200 }) }]
+  }));
+
+  if (!message) return null;
+
+  return (
+    <AnimatedView pointerEvents={visible ? 'auto' : 'none'} style={[styles.toast, containerStyle]}>
+      <Text style={styles.message}>{message}</Text>
+      {actionLabel && onAction ? (
+        <Pressable onPress={onAction} style={styles.actionButton} accessibilityRole="button">
+          <Text style={styles.actionText}>{actionLabel}</Text>
+        </Pressable>
+      ) : null}
+    </AnimatedView>
+  );
+};
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    bottom: Platform.select({ ios: 80, android: 40, default: 24 }),
+    left: spacing.lg,
+    right: spacing.lg,
+    backgroundColor: colors.surface,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 10,
+    elevation: 4,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md
+  },
+  message: {
+    flex: 1,
+    color: colors.text,
+    fontSize: 14
+  },
+  actionButton: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.sm,
+    backgroundColor: colors.primary
+  },
+  actionText: {
+    color: '#fff',
+    fontWeight: '600'
+  }
+});
+
+export default Toast;

--- a/src/lib/backoff.ts
+++ b/src/lib/backoff.ts
@@ -1,0 +1,5 @@
+export const exponentialBackoff = (attempt: number, baseMs = 500, maxMs = 6000): number => {
+  const exp = Math.min(maxMs, baseMs * Math.pow(2, attempt - 1));
+  const jitter = Math.random() * baseMs;
+  return Math.min(maxMs, exp + jitter);
+};

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,28 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const storage = {
+  async get<T>(key: string): Promise<T | undefined> {
+    try {
+      const raw = await AsyncStorage.getItem(key);
+      if (!raw) return undefined;
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      console.warn('Failed to read storage', error);
+      return undefined;
+    }
+  },
+  async set<T>(key: string, value: T): Promise<void> {
+    try {
+      await AsyncStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn('Failed to write storage', error);
+    }
+  },
+  async remove(key: string): Promise<void> {
+    try {
+      await AsyncStorage.removeItem(key);
+    } catch (error) {
+      console.warn('Failed to remove storage', error);
+    }
+  }
+};

--- a/src/services/actions.ts
+++ b/src/services/actions.ts
@@ -1,0 +1,79 @@
+import { exponentialBackoff } from '@/lib/backoff';
+import { ActionConfig, Item, Operation } from '@/types';
+
+const FAILURE_RATE = 0.08;
+const MIN_LATENCY = 200;
+const MAX_LATENCY = 800;
+
+const randomLatency = async () => {
+  const duration = Math.random() * (MAX_LATENCY - MIN_LATENCY) + MIN_LATENCY;
+  return new Promise((resolve) => setTimeout(resolve, duration));
+};
+
+const performAction = async (action: ActionConfig, item: Item) => {
+  await randomLatency();
+  if (Math.random() < FAILURE_RATE) {
+    throw new Error(`Action ${action.type} failed for ${item.id}`);
+  }
+};
+
+const performUndo = async (action: ActionConfig, item: Item) => {
+  await randomLatency();
+  if (Math.random() < FAILURE_RATE) {
+    throw new Error(`Undo ${action.type} failed for ${item.id}`);
+  }
+};
+
+type EnqueueCallbacks = {
+  onAttempt?: (attempt: number) => void;
+  onSuccess: () => void;
+  onFailure: (error: string) => void;
+};
+
+type QueueHandle = {
+  cancel: () => void;
+};
+
+export const enqueueOperation = (
+  operation: Operation,
+  callbacks: EnqueueCallbacks,
+  options?: { maxAttempts?: number },
+): QueueHandle => {
+  const maxAttempts = options?.maxAttempts ?? 5;
+  let cancelled = false;
+  let timeout: NodeJS.Timeout | undefined;
+
+  const attempt = async (attemptNumber: number) => {
+    if (cancelled) return;
+    callbacks.onAttempt?.(attemptNumber);
+    try {
+      if (operation.undo) {
+        await performUndo(operation.action, operation.item);
+      } else {
+        await performAction(operation.action, operation.item);
+      }
+      if (!cancelled) {
+        callbacks.onSuccess();
+      }
+    } catch (error) {
+      if (cancelled) return;
+      if (attemptNumber >= maxAttempts) {
+        callbacks.onFailure(error instanceof Error ? error.message : 'Unknown error');
+        return;
+      }
+      const delay = exponentialBackoff(attemptNumber + 1);
+      timeout = setTimeout(() => attempt(attemptNumber + 1), delay);
+    }
+  };
+
+  attempt(Math.max(1, operation.attempts + 1));
+
+  return {
+    cancel: () => {
+      cancelled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+};

--- a/src/services/connectors/gmail.ts
+++ b/src/services/connectors/gmail.ts
@@ -1,0 +1,25 @@
+import { ActionConfig } from '@/types';
+
+export const gmailPresets = {
+  labels: ['Starred', 'ReadLater', 'Archive']
+};
+
+export const gmailActions: ActionConfig[] = [
+  { type: 'Tag', params: { label: 'Starred' }, label: 'Label Starred' },
+  { type: 'Tag', params: { label: 'ReadLater' }, label: 'Label Read Later' },
+  { type: 'Archive', label: 'Archive email' },
+  { type: 'DoNothing', label: 'Do nothing' }
+];
+
+export const describeAction = (config: ActionConfig): string => {
+  switch (config.type) {
+    case 'Tag':
+      return `Apply label ${config.params?.label ?? ''}`.trim();
+    case 'Archive':
+      return 'Archive conversation';
+    default:
+      return 'Do nothing';
+  }
+};
+
+export const availableActions = (): ActionConfig[] => gmailActions;

--- a/src/services/connectors/index.ts
+++ b/src/services/connectors/index.ts
@@ -1,0 +1,32 @@
+import { ActionConfig, ConnectorId } from '@/types';
+import { availableActions as trelloActions, describeAction as describeTrello } from './trello';
+import { availableActions as gmailActions, describeAction as describeGmail } from './gmail';
+import { availableActions as notionActions, describeAction as describeNotion } from './notion';
+
+export const connectorNames: Record<ConnectorId, string> = {
+  trello: 'Trello',
+  gmail: 'Gmail',
+  notion: 'Notion'
+};
+
+export const connectorActions: Record<ConnectorId, () => ActionConfig[]> = {
+  trello: trelloActions,
+  gmail: gmailActions,
+  notion: notionActions
+};
+
+export const describeConnectorAction = (
+  connector: ConnectorId,
+  action: ActionConfig,
+): string => {
+  switch (connector) {
+    case 'trello':
+      return describeTrello(action);
+    case 'gmail':
+      return describeGmail(action);
+    case 'notion':
+      return describeNotion(action);
+    default:
+      return action.label ?? action.type;
+  }
+};

--- a/src/services/connectors/notion.ts
+++ b/src/services/connectors/notion.ts
@@ -1,0 +1,29 @@
+import { ActionConfig } from '@/types';
+
+export const notionPresets = {
+  databases: ['Ideas', 'Backlog'],
+  tags: ['Inspiration', 'Needs Research']
+};
+
+export const notionActions: ActionConfig[] = [
+  { type: 'Move', params: { database: 'Ideas' }, label: 'Move → Ideas' },
+  { type: 'Move', params: { database: 'Backlog' }, label: 'Move → Backlog' },
+  { type: 'Tag', params: { tag: 'Inspiration' }, label: 'Tag Inspiration' },
+  { type: 'Tag', params: { tag: 'Needs Research' }, label: 'Tag Needs Research' },
+  { type: 'DoNothing', label: 'Do nothing' }
+];
+
+export const describeAction = (config: ActionConfig): string => {
+  switch (config.type) {
+    case 'Move':
+      return `Move to ${config.params?.database ?? 'database'}`;
+    case 'Tag':
+      return `Add tag ${config.params?.tag ?? ''}`.trim();
+    case 'Archive':
+      return 'Archive page';
+    default:
+      return 'Do nothing';
+  }
+};
+
+export const availableActions = (): ActionConfig[] => notionActions;

--- a/src/services/connectors/trello.ts
+++ b/src/services/connectors/trello.ts
@@ -1,0 +1,31 @@
+import { ActionConfig } from '@/types';
+
+export const trelloPresets = {
+  lists: ['Inbox', 'Keep', 'Later'],
+  tags: ['Today', 'Research', 'Waiting']
+};
+
+export const trelloActions: ActionConfig[] = [
+  { type: 'Move', params: { list: 'Inbox' }, label: 'Move → Inbox' },
+  { type: 'Move', params: { list: 'Keep' }, label: 'Move → Keep' },
+  { type: 'Move', params: { list: 'Later' }, label: 'Move → Later' },
+  { type: 'Tag', params: { tag: 'Today' }, label: 'Tag Today' },
+  { type: 'Tag', params: { tag: 'Research' }, label: 'Tag Research' },
+  { type: 'Archive', label: 'Archive card' },
+  { type: 'DoNothing', label: 'Do nothing' }
+];
+
+export const describeAction = (config: ActionConfig): string => {
+  switch (config.type) {
+    case 'Move':
+      return `Move to ${config.params?.list ?? 'list'}`;
+    case 'Tag':
+      return `Add tag ${config.params?.tag ?? ''}`.trim();
+    case 'Archive':
+      return 'Archive card';
+    default:
+      return 'Do nothing';
+  }
+};
+
+export const availableActions = (): ActionConfig[] => trelloActions;

--- a/src/services/items.ts
+++ b/src/services/items.ts
@@ -1,0 +1,44 @@
+import { ConnectorId, Item } from '@/types';
+
+const ITEM_COUNT = 50;
+const PAGE_SIZE = 10;
+
+const generateItems = (connector: ConnectorId): Item[] => {
+  const suffix = connector.toUpperCase();
+  return new Array(ITEM_COUNT).fill(null).map((_, index) => {
+    const id = `${connector}-${index + 1}`;
+    return {
+      id,
+      title: `${suffix} Item #${index + 1}`,
+      preview: `This is a mocked preview for ${suffix} item ${index + 1}.`,
+      thumbnailUrl: undefined,
+      meta: {
+        connector,
+        position: index + 1
+      }
+    } satisfies Item;
+  });
+};
+
+const cache = new Map<ConnectorId, Item[]>();
+
+export const getItemsPage = async (
+  connector: ConnectorId,
+  page: number,
+): Promise<{ items: Item[]; hasMore: boolean }> => {
+  if (!cache.has(connector)) {
+    cache.set(connector, generateItems(connector));
+  }
+
+  const items = cache.get(connector)!;
+  const start = page * PAGE_SIZE;
+  const end = start + PAGE_SIZE;
+  const slice = items.slice(start, end);
+  const hasMore = end < items.length;
+
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  return { items: slice, hasMore };
+};
+
+export const pageSize = PAGE_SIZE;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,0 +1,399 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { ConnectorId, Operation } from '@/types';
+import { storage } from '@/lib/storage';
+import { getItemsPage } from '@/services/items';
+import { connectorNames, describeConnectorAction } from '@/services/connectors';
+import { enqueueOperation } from '@/services/actions';
+import { useToastStore } from './useToastStore';
+
+const STORAGE_ACCOUNT_KEY = 'swipeflow:account';
+const STORAGE_MAP_KEY = 'swipeflow:map';
+const STORAGE_UNDO_KEY = 'swipeflow:undo';
+const STORAGE_HAPTIC_KEY = 'swipeflow:haptics';
+
+export type Account = { connector: ConnectorId } | null;
+
+type SwipeMap = {
+  left: Operation['action'];
+  right: Operation['action'];
+};
+
+type AppState = {
+  account: Account;
+  swipeMap: SwipeMap;
+  deck: Operation['item'][];
+  queue: Operation[];
+  undoStack: Operation[];
+  hasMore: boolean;
+  page: number;
+  loading: boolean;
+  hapticsEnabled: boolean;
+  init: () => Promise<void>;
+  setAccount: (connector: ConnectorId | null) => Promise<void>;
+  setSwipeMap: (updates: Partial<SwipeMap>) => Promise<void>;
+  loadPage: () => Promise<void>;
+  swipe: (direction: 'left' | 'right') => Promise<void>;
+  undo: () => Promise<void>;
+  retry: (operationId: string) => Promise<void>;
+  clearCache: () => Promise<void>;
+  setHaptics: (value: boolean) => Promise<void>;
+};
+
+const defaultSwipeMap: SwipeMap = {
+  left: { type: 'Archive' },
+  right: { type: 'Move', params: { list: 'Keep' } }
+};
+
+const operationHandles = new Map<string, ReturnType<typeof enqueueOperation>>();
+
+export const useAppStore = create<AppState>()(
+  immer((set, get) => ({
+    account: null,
+    swipeMap: defaultSwipeMap,
+    deck: [],
+    queue: [],
+    undoStack: [],
+    hasMore: true,
+    page: 0,
+    loading: false,
+    hapticsEnabled: true,
+    init: async () => {
+      const [account, swipeMap, undoStack, haptics] = await Promise.all([
+        storage.get<Account>(STORAGE_ACCOUNT_KEY),
+        storage.get<SwipeMap>(STORAGE_MAP_KEY),
+        storage.get<Operation[]>(STORAGE_UNDO_KEY),
+        storage.get<boolean>(STORAGE_HAPTIC_KEY)
+      ]);
+
+      set((state) => {
+        state.account = account ?? null;
+        if (swipeMap) state.swipeMap = swipeMap;
+        if (undoStack) state.undoStack = undoStack;
+        if (typeof haptics === 'boolean') state.hapticsEnabled = haptics;
+        state.page = 0;
+        state.deck = [];
+        state.hasMore = true;
+      });
+
+      if (account) {
+        await get().loadPage();
+      }
+    },
+    setAccount: async (connector) => {
+      if (!connector) {
+        set((state) => {
+          state.account = null;
+          state.deck = [];
+          state.page = 0;
+          state.hasMore = true;
+          state.queue = [];
+          state.undoStack = [];
+        });
+        await storage.remove(STORAGE_ACCOUNT_KEY);
+        await storage.remove(STORAGE_UNDO_KEY);
+        return;
+      }
+
+      set((state) => {
+        state.account = { connector };
+        state.deck = [];
+        state.page = 0;
+        state.hasMore = true;
+        state.queue = [];
+        state.undoStack = [];
+      });
+      await storage.set(STORAGE_ACCOUNT_KEY, { connector });
+      await storage.remove(STORAGE_UNDO_KEY);
+      await get().loadPage();
+    },
+    setSwipeMap: async (updates) => {
+      set((state) => {
+        state.swipeMap = { ...state.swipeMap, ...updates };
+      });
+      await storage.set(STORAGE_MAP_KEY, get().swipeMap);
+    },
+    loadPage: async () => {
+      const { account, loading, hasMore, page } = get();
+      if (!account || loading || !hasMore) return;
+      set((state) => {
+        state.loading = true;
+      });
+      try {
+        const { items, hasMore: nextHasMore } = await getItemsPage(account.connector, page);
+        set((state) => {
+          state.deck.push(...items);
+          state.hasMore = nextHasMore;
+          state.page = state.page + 1;
+        });
+      } finally {
+        set((state) => {
+          state.loading = false;
+        });
+      }
+    },
+    swipe: async (direction) => {
+      const { deck, swipeMap, account } = get();
+      if (!account) return;
+      if (!deck.length) {
+        await get().loadPage();
+        return;
+      }
+      const item = deck[0];
+      const remaining = deck.slice(1);
+      const action = swipeMap[direction];
+      const now = Date.now();
+      const operation: Operation = {
+        id: `${now}-${Math.random().toString(36).slice(2, 8)}`,
+        item,
+        direction,
+        action,
+        status: 'pending',
+        attempts: 0,
+        createdAt: now,
+        updatedAt: now
+      };
+
+      set((state) => {
+        state.deck = remaining;
+        state.queue.unshift(operation);
+        state.undoStack.unshift(operation);
+        state.undoStack = state.undoStack.slice(0, 10);
+      });
+      await storage.set(STORAGE_UNDO_KEY, get().undoStack);
+
+      const toast = useToastStore.getState();
+
+      const handle = enqueueOperation(operation, {
+        onAttempt: (attempt) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operation.id);
+            if (entry) {
+              entry.attempts = attempt;
+              entry.updatedAt = Date.now();
+            }
+          });
+        },
+        onSuccess: () => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operation.id);
+            if (entry) {
+              entry.status = 'success';
+              entry.error = undefined;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(operation.id);
+          toast.show({
+            message: `${connectorNames[account.connector]}: ${describeConnectorAction(
+              account.connector,
+              action,
+            )} succeeded`,
+            type: 'success'
+          });
+        },
+        onFailure: (error) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operation.id);
+            if (entry) {
+              entry.status = 'failed';
+              entry.error = error;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(operation.id);
+          toast.show({
+            message: `${connectorNames[account.connector]} action failed`,
+            type: 'error',
+            actionLabel: 'Retry',
+            onAction: () => {
+              void get().retry(operation.id);
+            },
+            duration: 4000
+          });
+        }
+      });
+
+      operationHandles.set(operation.id, handle);
+
+      if (remaining.length < 5) {
+        void get().loadPage();
+      }
+    },
+    undo: async () => {
+      const { undoStack, deck, account } = get();
+      if (!undoStack.length || !account) return;
+
+      const [lastOperation, ...rest] = undoStack;
+      set((state) => {
+        state.undoStack = rest;
+      });
+      await storage.set(STORAGE_UNDO_KEY, rest);
+
+      const handle = operationHandles.get(lastOperation.id);
+      if (handle) {
+        handle.cancel();
+        operationHandles.delete(lastOperation.id);
+      }
+
+      set((state) => {
+        state.deck = [lastOperation.item, ...deck];
+        const entry = state.queue.find((op) => op.id === lastOperation.id);
+        if (entry) {
+          entry.status = 'success';
+          entry.updatedAt = Date.now();
+          entry.error = undefined;
+        }
+      });
+
+      const revertOperation: Operation = {
+        ...lastOperation,
+        id: `${Date.now()}-undo-${Math.random().toString(36).slice(2, 8)}`,
+        undo: true,
+        status: 'pending',
+        attempts: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+
+      set((state) => {
+        state.queue.unshift(revertOperation);
+      });
+
+      const toast = useToastStore.getState();
+
+      const revertHandle = enqueueOperation(revertOperation, {
+        onAttempt: (attempt) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === revertOperation.id);
+            if (entry) {
+              entry.attempts = attempt;
+              entry.updatedAt = Date.now();
+            }
+          });
+        },
+        onSuccess: () => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === revertOperation.id);
+            if (entry) {
+              entry.status = 'success';
+              entry.error = undefined;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(revertOperation.id);
+          toast.show({ message: 'Undo successful', type: 'success' });
+        },
+        onFailure: (error) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === revertOperation.id);
+            if (entry) {
+              entry.status = 'failed';
+              entry.error = error;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(revertOperation.id);
+          toast.show({
+            message: 'Undo failed',
+            type: 'error',
+            actionLabel: 'Retry',
+            onAction: () => void get().retry(revertOperation.id),
+            duration: 4000
+          });
+        }
+      });
+
+      operationHandles.set(revertOperation.id, revertHandle);
+    },
+    retry: async (operationId) => {
+      const { account } = get();
+      if (!account) return;
+      const existing = get().queue.find((op) => op.id === operationId);
+      if (!existing) return;
+
+      const handle = operationHandles.get(operationId);
+      if (handle) {
+        handle.cancel();
+        operationHandles.delete(operationId);
+      }
+
+      const resetOperation: Operation = {
+        ...existing,
+        status: 'pending',
+        attempts: existing.attempts,
+        error: undefined,
+        updatedAt: Date.now()
+      };
+
+      set((state) => {
+        const index = state.queue.findIndex((op) => op.id === operationId);
+        if (index !== -1) {
+          state.queue[index] = resetOperation;
+        }
+      });
+
+      const toast = useToastStore.getState();
+
+      const newHandle = enqueueOperation(resetOperation, {
+        onAttempt: (attempt) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operationId);
+            if (entry) {
+              entry.attempts = attempt;
+              entry.updatedAt = Date.now();
+            }
+          });
+        },
+        onSuccess: () => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operationId);
+            if (entry) {
+              entry.status = 'success';
+              entry.error = undefined;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(operationId);
+          toast.show({ message: 'Action completed', type: 'success' });
+        },
+        onFailure: (error) => {
+          set((state) => {
+            const entry = state.queue.find((op) => op.id === operationId);
+            if (entry) {
+              entry.status = 'failed';
+              entry.error = error;
+              entry.updatedAt = Date.now();
+            }
+          });
+          operationHandles.delete(operationId);
+          toast.show({
+            message: 'Action failed again',
+            type: 'error',
+            actionLabel: 'Retry',
+            onAction: () => void get().retry(operationId),
+            duration: 4000
+          });
+        }
+      });
+
+      operationHandles.set(operationId, newHandle);
+    },
+    clearCache: async () => {
+      set((state) => {
+        state.deck = [];
+        state.page = 0;
+        state.hasMore = true;
+        state.queue = [];
+        state.undoStack = [];
+      });
+      await storage.remove(STORAGE_UNDO_KEY);
+    },
+    setHaptics: async (value) => {
+      set((state) => {
+        state.hapticsEnabled = value;
+      });
+      await storage.set(STORAGE_HAPTIC_KEY, value);
+    }
+  })),
+);

--- a/src/store/useToastStore.ts
+++ b/src/store/useToastStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+export type ToastType = 'info' | 'success' | 'error';
+
+export type ToastState = {
+  id?: string;
+  message?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  type: ToastType;
+  visible: boolean;
+  show: (payload: {
+    message: string;
+    type?: ToastType;
+    actionLabel?: string;
+    onAction?: () => void;
+    duration?: number;
+  }) => void;
+  hide: () => void;
+};
+
+export const useToastStore = create<ToastState>((set) => ({
+  type: 'info',
+  visible: false,
+  show: ({ message, type = 'info', actionLabel, onAction, duration = 2500 }) => {
+    const id = `${Date.now()}`;
+    set({ id, message, type, actionLabel, onAction, visible: true });
+    if (duration > 0) {
+      setTimeout(() => {
+        set((state) => (state.id === id ? { visible: false } : state));
+      }, duration);
+    }
+  },
+  hide: () => set({ visible: false })
+}));

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,33 @@
+export const colors = {
+  background: '#f5f5f7',
+  surface: '#ffffff',
+  primary: '#2563eb',
+  text: '#111827',
+  muted: '#6b7280',
+  success: '#10b981',
+  danger: '#ef4444'
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32
+};
+
+export const radii = {
+  sm: 8,
+  md: 16,
+  lg: 24
+};
+
+export const shadows = {
+  card: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 6
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export type ConnectorId = 'trello' | 'gmail' | 'notion';
+
+export type ActionType = 'Move' | 'Tag' | 'Archive' | 'DoNothing';
+
+export type ActionConfig = {
+  type: ActionType;
+  params?: Record<string, string>;
+  label?: string;
+};
+
+export type Item = {
+  id: string;
+  title: string;
+  preview?: string;
+  thumbnailUrl?: string;
+  meta?: Record<string, any>;
+};
+
+export type OperationStatus = 'pending' | 'success' | 'failed';
+
+export type Operation = {
+  id: string;
+  item: Item;
+  direction: 'left' | 'right';
+  action: ActionConfig;
+  status: OperationStatus;
+  error?: string;
+  attempts: number;
+  createdAt: number;
+  updatedAt: number;
+  undo?: boolean;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["react", "react-native", "expo-router"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "expo-env.d.ts"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}


### PR DESCRIPTION
## Summary
- scaffold the SwipeFlow Expo Router TypeScript app with mocked connectors and services
- build Zustand-powered state with swipe deck, undo stack, and retryable action queue
- implement gesture-driven deck, onboarding, mapping, activity, and settings screens with toast feedback

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e673b7df6c833389a3ab3fd7a3d97a